### PR TITLE
Add final itinerary display view

### DIFF
--- a/frontend/TravelPlanner/TravelPlanner/Models/Itinerary.swift
+++ b/frontend/TravelPlanner/TravelPlanner/Models/Itinerary.swift
@@ -1,1 +1,75 @@
-// Itinerary and activity models
+import Foundation
+
+// MARK: - Itinerary Generation Response Models
+
+/// Response from the `/itinerary/generate` endpoint
+struct ItineraryResponse: Codable {
+    let errors: [BackendError]?
+    let itinerary: GeneratedItinerary?
+    let summary: ItinerarySummary?
+}
+
+/// Main itinerary object containing all trip details
+struct GeneratedItinerary: Codable {
+    let destination: String
+    let totalDays: Int
+    let dailySchedules: [DailySchedule]
+    
+    enum CodingKeys: String, CodingKey {
+        case destination
+        case totalDays = "total_days"
+        case dailySchedules = "daily_schedules"
+    }
+}
+
+/// Individual day schedule with activities and metrics
+struct DailySchedule: Codable {
+    let date: String
+    let dayNumber: Int
+    let theme: String
+    let activities: [ScheduledActivity]
+    let dailyCost: Int
+    let walkingDistance: String
+    
+    enum CodingKeys: String, CodingKey {
+        case date
+        case dayNumber = "day_number"
+        case theme
+        case activities
+        case dailyCost = "daily_cost"
+        case walkingDistance = "walking_distance"
+    }
+}
+
+/// Time-based activity within a daily schedule
+struct ScheduledActivity: Codable {
+    let startTime: String
+    let endTime: String
+    let activity: ActivityDetail
+    
+    enum CodingKeys: String, CodingKey {
+        case startTime = "start_time"
+        case endTime = "end_time"
+        case activity
+    }
+}
+
+/// Detailed activity information
+struct ActivityDetail: Codable {
+    let name: String
+    let type: String
+    let notes: String?
+}
+
+/// Summary metrics for the entire itinerary
+struct ItinerarySummary: Codable {
+    let totalCost: Int
+    let totalActivities: Int
+    let optimizationScore: Double
+    
+    enum CodingKeys: String, CodingKey {
+        case totalCost = "total_cost"
+        case totalActivities = "total_activities"
+        case optimizationScore = "optimization_score"
+    }
+}

--- a/frontend/TravelPlanner/TravelPlanner/Models/MockData.swift
+++ b/frontend/TravelPlanner/TravelPlanner/Models/MockData.swift
@@ -137,4 +137,386 @@ struct MockData {
             ]
         )
     }
+    
+    /// Returns comprehensive mock itinerary response matching the backend API exactly
+    static func mockItineraryResponse() -> ItineraryResponse {
+        return ItineraryResponse(
+            errors: nil,
+            itinerary: GeneratedItinerary(
+                destination: "Barcelona, Spain",
+                totalDays: 7,
+                dailySchedules: [
+                    // Day 1: Arrival & Gothic Quarter
+                    DailySchedule(
+                        date: "2024-07-15",
+                        dayNumber: 1,
+                        theme: "Arrival & Gothic Quarter",
+                        activities: [
+                            ScheduledActivity(
+                                startTime: "14:00",
+                                endTime: "15:00",
+                                activity: ActivityDetail(
+                                    name: "Hotel Check-in",
+                                    type: "logistics",
+                                    notes: "Relax after arrival"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "15:30",
+                                endTime: "17:30",
+                                activity: ActivityDetail(
+                                    name: "Las Ramblas Walk",
+                                    type: "cultural",
+                                    notes: "Introduction to the city"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "18:00",
+                                endTime: "19:30",
+                                activity: ActivityDetail(
+                                    name: "Dinner at El Xampanyet",
+                                    type: "dining",
+                                    notes: "Traditional tapas experience"
+                                )
+                            )
+                        ],
+                        dailyCost: 85,
+                        walkingDistance: "3.2 km"
+                    ),
+                    
+                    // Day 2: Gaudí Architecture
+                    DailySchedule(
+                        date: "2024-07-16",
+                        dayNumber: 2,
+                        theme: "Gaudí Architecture Day",
+                        activities: [
+                            ScheduledActivity(
+                                startTime: "09:00",
+                                endTime: "09:30",
+                                activity: ActivityDetail(
+                                    name: "Hotel Breakfast",
+                                    type: "dining",
+                                    notes: "Start your day with energy"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "10:00",
+                                endTime: "12:30",
+                                activity: ActivityDetail(
+                                    name: "Sagrada Familia Tour",
+                                    type: "cultural",
+                                    notes: "Skip-the-line tickets included"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "13:00",
+                                endTime: "14:00",
+                                activity: ActivityDetail(
+                                    name: "Lunch at Cerveseria Catalana",
+                                    type: "dining",
+                                    notes: "Famous for their tapas"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "15:00",
+                                endTime: "17:00",
+                                activity: ActivityDetail(
+                                    name: "Park Güell",
+                                    type: "outdoor",
+                                    notes: "Colorful park with city views"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "19:00",
+                                endTime: "20:30",
+                                activity: ActivityDetail(
+                                    name: "Dinner at Cal Pep",
+                                    type: "dining",
+                                    notes: "Iconic seafood tapas bar"
+                                )
+                            )
+                        ],
+                        dailyCost: 120,
+                        walkingDistance: "4.8 km"
+                    ),
+                    
+                    // Day 3: Art & Culture
+                    DailySchedule(
+                        date: "2024-07-17",
+                        dayNumber: 3,
+                        theme: "Art & Culture Immersion",
+                        activities: [
+                            ScheduledActivity(
+                                startTime: "09:30",
+                                endTime: "10:00",
+                                activity: ActivityDetail(
+                                    name: "Coffee at Els Quatre Gats",
+                                    type: "dining",
+                                    notes: "Historic café where Picasso used to meet"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "10:30",
+                                endTime: "12:30",
+                                activity: ActivityDetail(
+                                    name: "Picasso Museum",
+                                    type: "cultural",
+                                    notes: "Extensive collection of early works"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "13:00",
+                                endTime: "14:00",
+                                activity: ActivityDetail(
+                                    name: "Lunch at Bar del Pla",
+                                    type: "dining",
+                                    notes: "Modern tapas in Gothic Quarter"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "15:00",
+                                endTime: "16:30",
+                                activity: ActivityDetail(
+                                    name: "Casa Batlló",
+                                    type: "cultural",
+                                    notes: "Modernist masterpiece with audio guide"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "17:00",
+                                endTime: "18:30",
+                                activity: ActivityDetail(
+                                    name: "La Boqueria Market",
+                                    type: "food",
+                                    notes: "Famous food market experience"
+                                )
+                            )
+                        ],
+                        dailyCost: 95,
+                        walkingDistance: "5.1 km"
+                    ),
+                    
+                    // Day 4: Beach & Neighborhoods
+                    DailySchedule(
+                        date: "2024-07-18",
+                        dayNumber: 4,
+                        theme: "Beach & Local Neighborhoods",
+                        activities: [
+                            ScheduledActivity(
+                                startTime: "10:00",
+                                endTime: "13:00",
+                                activity: ActivityDetail(
+                                    name: "Barceloneta Beach",
+                                    type: "outdoor",
+                                    notes: "Relax and swim at the city beach"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "13:30",
+                                endTime: "14:30",
+                                activity: ActivityDetail(
+                                    name: "Seafood Lunch at Barceloneta",
+                                    type: "dining",
+                                    notes: "Fresh seafood by the beach"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "16:00",
+                                endTime: "18:00",
+                                activity: ActivityDetail(
+                                    name: "El Born District Walk",
+                                    type: "cultural",
+                                    notes: "Trendy neighborhood with boutiques"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "18:30",
+                                endTime: "19:30",
+                                activity: ActivityDetail(
+                                    name: "Santa Maria del Mar",
+                                    type: "cultural",
+                                    notes: "Beautiful Gothic church"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "20:00",
+                                endTime: "21:30",
+                                activity: ActivityDetail(
+                                    name: "Dinner at Euskal Etxea",
+                                    type: "dining",
+                                    notes: "Basque pintxos bar"
+                                )
+                            )
+                        ],
+                        dailyCost: 75,
+                        walkingDistance: "6.2 km"
+                    ),
+                    
+                    // Day 5: Montjuïc Hill
+                    DailySchedule(
+                        date: "2024-07-19",
+                        dayNumber: 5,
+                        theme: "Montjuïc Hill Exploration",
+                        activities: [
+                            ScheduledActivity(
+                                startTime: "09:30",
+                                endTime: "10:00",
+                                activity: ActivityDetail(
+                                    name: "Cable Car to Montjuïc",
+                                    type: "logistics",
+                                    notes: "Scenic ride up the hill"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "10:30",
+                                endTime: "12:00",
+                                activity: ActivityDetail(
+                                    name: "Fundació Joan Miró",
+                                    type: "cultural",
+                                    notes: "Modern art museum dedicated to Miró"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "12:30",
+                                endTime: "13:30",
+                                activity: ActivityDetail(
+                                    name: "Lunch at Martínez Restaurant",
+                                    type: "dining",
+                                    notes: "Panoramic views of the city"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "14:30",
+                                endTime: "16:00",
+                                activity: ActivityDetail(
+                                    name: "Montjuïc Castle",
+                                    type: "historical",
+                                    notes: "Historic fortress with harbor views"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "17:00",
+                                endTime: "18:00",
+                                activity: ActivityDetail(
+                                    name: "Magic Fountain Show",
+                                    type: "entertainment",
+                                    notes: "Evening light and music show"
+                                )
+                            )
+                        ],
+                        dailyCost: 90,
+                        walkingDistance: "3.5 km"
+                    ),
+                    
+                    // Day 6: Day Trip to Girona
+                    DailySchedule(
+                        date: "2024-07-20",
+                        dayNumber: 6,
+                        theme: "Day Trip to Girona",
+                        activities: [
+                            ScheduledActivity(
+                                startTime: "08:00",
+                                endTime: "09:30",
+                                activity: ActivityDetail(
+                                    name: "Train to Girona",
+                                    type: "logistics",
+                                    notes: "1.5 hour scenic train ride"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "10:00",
+                                endTime: "12:00",
+                                activity: ActivityDetail(
+                                    name: "Girona Cathedral & Old Town",
+                                    type: "cultural",
+                                    notes: "Medieval architecture and Game of Thrones filming locations"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "12:30",
+                                endTime: "13:30",
+                                activity: ActivityDetail(
+                                    name: "Lunch at Casa Marieta",
+                                    type: "dining",
+                                    notes: "Traditional Catalan cuisine"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "14:00",
+                                endTime: "16:00",
+                                activity: ActivityDetail(
+                                    name: "Jewish Quarter Walk",
+                                    type: "historical",
+                                    notes: "One of Europe's best-preserved Jewish quarters"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "18:00",
+                                endTime: "19:30",
+                                activity: ActivityDetail(
+                                    name: "Return Train to Barcelona",
+                                    type: "logistics",
+                                    notes: "Back to Barcelona for evening"
+                                )
+                            )
+                        ],
+                        dailyCost: 110,
+                        walkingDistance: "8.0 km"
+                    ),
+                    
+                    // Day 7: Farewell Barcelona
+                    DailySchedule(
+                        date: "2024-07-21",
+                        dayNumber: 7,
+                        theme: "Farewell Barcelona",
+                        activities: [
+                            ScheduledActivity(
+                                startTime: "10:00",
+                                endTime: "11:30",
+                                activity: ActivityDetail(
+                                    name: "Casa Milà (La Pedrera)",
+                                    type: "cultural",
+                                    notes: "Final Gaudí masterpiece visit"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "12:00",
+                                endTime: "13:00",
+                                activity: ActivityDetail(
+                                    name: "Souvenir Shopping on Passeig de Gràcia",
+                                    type: "shopping",
+                                    notes: "Last-minute gifts and memories"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "13:30",
+                                endTime: "15:00",
+                                activity: ActivityDetail(
+                                    name: "Farewell Lunch at 7 Portes",
+                                    type: "dining",
+                                    notes: "Historic restaurant serving paella since 1836"
+                                )
+                            ),
+                            ScheduledActivity(
+                                startTime: "16:00",
+                                endTime: "17:00",
+                                activity: ActivityDetail(
+                                    name: "Hotel Check-out & Departure",
+                                    type: "logistics",
+                                    notes: "End of your Barcelona adventure"
+                                )
+                            )
+                        ],
+                        dailyCost: 80,
+                        walkingDistance: "2.8 km"
+                    )
+                ]
+            ),
+            summary: ItinerarySummary(
+                totalCost: 655,
+                totalActivities: 28,
+                optimizationScore: 0.91
+            )
+        )
+    }
 }

--- a/frontend/TravelPlanner/TravelPlanner/Models/UserPreferences.swift
+++ b/frontend/TravelPlanner/TravelPlanner/Models/UserPreferences.swift
@@ -114,6 +114,7 @@ enum QuestionnaireStep: Int, CaseIterable {
     case mealPreferences = 17
     case transportation = 18
     case itinerarySummary = 19
+    case itineraryDisplay = 20
     
     var title: String {
         switch self {
@@ -138,6 +139,7 @@ enum QuestionnaireStep: Int, CaseIterable {
         case .mealPreferences: return "Dining Preferences"
         case .transportation: return "Transportation"
         case .itinerarySummary: return "Itinerary Summary"
+        case .itineraryDisplay: return "Your Itinerary"
         }
     }
     

--- a/frontend/TravelPlanner/TravelPlanner/Views/Questionnaire/ItineraryDisplayView.swift
+++ b/frontend/TravelPlanner/TravelPlanner/Views/Questionnaire/ItineraryDisplayView.swift
@@ -1,0 +1,456 @@
+import SwiftUI
+
+/// Final step: Displays the complete generated itinerary to the user
+struct ItineraryDisplayView: View {
+    @ObservedObject var coordinator: QuestionnaireCoordinator
+    @State private var expandedDays: Set<Int> = []
+    
+    private var itinerary: GeneratedItinerary? {
+        coordinator.generatedItinerary?.itinerary
+    }
+    
+    private var summary: ItinerarySummary? {
+        coordinator.generatedItinerary?.summary
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if let itinerary = itinerary, let summary = summary {
+                ScrollView {
+                    VStack(spacing: 20) {
+                        // Header Section
+                        itineraryHeader(itinerary: itinerary, summary: summary)
+                        
+                        // Daily Schedule Cards
+                        LazyVStack(spacing: 16) {
+                            ForEach(itinerary.dailySchedules, id: \.dayNumber) { day in
+                                DayScheduleCard(
+                                    day: day,
+                                    isExpanded: expandedDays.contains(day.dayNumber)
+                                ) {
+                                    toggleDayExpansion(day.dayNumber)
+                                }
+                            }
+                        }
+                        .padding(.horizontal)
+                        
+                        // Summary Statistics
+                        itinerarySummarySection(summary: summary)
+                        
+                        // Action Buttons
+                        actionButtons()
+                    }
+                    .padding(.vertical)
+                }
+            } else {
+                // Loading or error state
+                VStack(spacing: 24) {
+                    Spacer()
+                    
+                    if coordinator.isGeneratingItinerary {
+                        VStack(spacing: 16) {
+                            ProgressView()
+                                .scaleEffect(1.5)
+                                .progressViewStyle(CircularProgressViewStyle(tint: .blue))
+                            
+                            Text("Generating your perfect itinerary...")
+                                .font(.title2)
+                                .fontWeight(.medium)
+                                .multilineTextAlignment(.center)
+                            
+                            Text("This may take a few seconds while we optimize your activities and schedule.")
+                                .font(.body)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal)
+                        }
+                        .padding()
+                        .background(Color(.systemGray6))
+                        .cornerRadius(16)
+                        .padding(.horizontal)
+                    } else {
+                        VStack(spacing: 16) {
+                            Image(systemName: "exclamationmark.triangle")
+                                .font(.largeTitle)
+                                .foregroundColor(.orange)
+                            
+                            Text("Unable to generate itinerary")
+                                .font(.headline)
+                            
+                            Text("Please try again or go back to modify your preferences.")
+                                .font(.body)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal)
+                        }
+                    }
+                    
+                    Spacer()
+                }
+                .padding()
+            }
+        }
+    }
+    
+    // MARK: - Header Section
+    @ViewBuilder
+    private func itineraryHeader(itinerary: GeneratedItinerary, summary: ItinerarySummary) -> some View {
+        VStack(spacing: 16) {
+            // Destination and dates
+            VStack(spacing: 8) {
+                Text(itinerary.destination)
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .multilineTextAlignment(.center)
+                
+                if let firstDay = itinerary.dailySchedules.first,
+                   let lastDay = itinerary.dailySchedules.last {
+                    Text("\(formatDate(firstDay.date)) - \(formatDate(lastDay.date))")
+                        .font(.title3)
+                        .foregroundColor(.secondary)
+                }
+                
+                Text("\(itinerary.totalDays) days • \(summary.totalActivities) activities")
+                    .font(.subheadline)
+                    .foregroundColor(.blue)
+                    .fontWeight(.medium)
+            }
+            
+            // Key stats
+            HStack(spacing: 24) {
+                StatCard(
+                    icon: "dollarsign.circle",
+                    title: "Estimated Cost",
+                    value: "$\(summary.totalCost)",
+                    color: .green
+                )
+                
+                StatCard(
+                    icon: "star.circle",
+                    title: "Optimization",
+                    value: "\(Int(summary.optimizationScore * 100))%",
+                    color: .blue
+                )
+                
+                StatCard(
+                    icon: "checkmark.circle",
+                    title: "Activities",
+                    value: "\(summary.totalActivities)",
+                    color: .orange
+                )
+            }
+        }
+        .padding()
+        .background(Color(.systemGray6))
+        .cornerRadius(16)
+        .padding(.horizontal)
+    }
+    
+    // MARK: - Summary Section
+    @ViewBuilder
+    private func itinerarySummarySection(summary: ItinerarySummary) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "chart.bar")
+                    .foregroundColor(.blue)
+                    .font(.title3)
+                
+                Text("Trip Summary")
+                    .font(.headline)
+                    .fontWeight(.medium)
+                
+                Spacer()
+            }
+            
+            VStack(alignment: .leading, spacing: 8) {
+                SummaryRow(label: "Estimated Budget", value: "$\(summary.totalCost)")
+                SummaryRow(label: "Total Activities", value: "\(summary.totalActivities)")
+                SummaryRow(label: "Optimization Score", value: "\(Int(summary.optimizationScore * 100))% match to your preferences")
+            }
+        }
+        .padding()
+        .background(Color(.systemGray6))
+        .cornerRadius(12)
+        .padding(.horizontal)
+    }
+    
+    // MARK: - Action Buttons
+    @ViewBuilder
+    private func actionButtons() -> some View {
+        VStack(spacing: 16) {
+            // Export button (placeholder for future PDF functionality)
+            Button(action: {
+                // TODO: Implement PDF export
+            }) {
+                HStack {
+                    Image(systemName: "square.and.arrow.up")
+                    Text("Export Itinerary")
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.blue)
+                .foregroundColor(.white)
+                .cornerRadius(12)
+                .font(.headline)
+            }
+            
+            // Start over button
+            Button(action: {
+                coordinator.resetQuestionnaire()
+            }) {
+                HStack {
+                    Image(systemName: "arrow.counterclockwise")
+                    Text("Plan Another Trip")
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color(.systemGray5))
+                .foregroundColor(.primary)
+                .cornerRadius(12)
+                .font(.headline)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.bottom)
+    }
+    
+    // MARK: - Helper Methods
+    private func toggleDayExpansion(_ dayNumber: Int) {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            if expandedDays.contains(dayNumber) {
+                expandedDays.remove(dayNumber)
+            } else {
+                expandedDays.insert(dayNumber)
+            }
+        }
+    }
+    
+    private func formatDate(_ dateString: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd"
+        
+        let outputFormatter = DateFormatter()
+        outputFormatter.dateFormat = "MMM d"
+        
+        if let date = inputFormatter.date(from: dateString) {
+            return outputFormatter.string(from: date)
+        }
+        return dateString
+    }
+}
+
+// MARK: - Supporting Views
+
+/// Individual day schedule card with expandable activities
+struct DayScheduleCard: View {
+    let day: DailySchedule
+    let isExpanded: Bool
+    let onTap: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Day header (always visible)
+            Button(action: onTap) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Day \(day.dayNumber)")
+                            .font(.headline)
+                            .fontWeight(.semibold)
+                        
+                        Text(day.theme)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    Spacer()
+                    
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Text("$\(day.dailyCost)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundColor(.green)
+                        
+                        Text(day.walkingDistance)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .foregroundColor(.blue)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+                .padding()
+            }
+            .buttonStyle(PlainButtonStyle())
+            
+            // Activities (expandable)
+            if isExpanded {
+                VStack(spacing: 12) {
+                    ForEach(Array(day.activities.enumerated()), id: \.offset) { index, activity in
+                        ActivityRow(activity: activity, isLast: index == day.activities.count - 1)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.bottom)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .background(Color(.systemBackground))
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
+    }
+}
+
+/// Individual activity row within a day
+struct ActivityRow: View {
+    let activity: ScheduledActivity
+    let isLast: Bool
+    
+    private var activityTypeColor: Color {
+        switch activity.activity.type {
+        case "cultural": return .blue
+        case "dining": return .orange
+        case "outdoor": return .green
+        case "historical": return .purple
+        case "logistics": return .gray
+        case "entertainment": return .pink
+        case "shopping": return .red
+        case "food": return .orange
+        default: return .blue
+        }
+    }
+    
+    private var activityTypeIcon: String {
+        switch activity.activity.type {
+        case "cultural": return "building.columns"
+        case "dining": return "fork.knife"
+        case "outdoor": return "leaf"
+        case "historical": return "books.vertical"
+        case "logistics": return "suitcase"
+        case "entertainment": return "theatermasks"
+        case "shopping": return "bag"
+        case "food": return "fork.knife"
+        default: return "star"
+        }
+    }
+    
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Time column
+            VStack(alignment: .leading, spacing: 2) {
+                Text(activity.startTime)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(.primary)
+                
+                Text(activity.endTime)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .frame(width: 50, alignment: .leading)
+            
+            // Timeline indicator
+            VStack(spacing: 4) {
+                Circle()
+                    .fill(activityTypeColor)
+                    .frame(width: 10, height: 10)
+                
+                if !isLast {
+                    Rectangle()
+                        .fill(Color(.systemGray4))
+                        .frame(width: 2, height: 30)
+                }
+            }
+            
+            // Activity details
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: activityTypeIcon)
+                        .foregroundColor(activityTypeColor)
+                        .font(.subheadline)
+                    
+                    Text(activity.activity.name)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    
+                    Spacer()
+                }
+                
+                if let notes = activity.activity.notes, !notes.isEmpty {
+                    Text(notes)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+/// Small stat card for the header
+struct StatCard: View {
+    let icon: String
+    let title: String
+    let value: String
+    let color: Color
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            Image(systemName: icon)
+                .foregroundColor(color)
+                .font(.title2)
+            
+            Text(value)
+                .font(.headline)
+                .fontWeight(.semibold)
+            
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+    }
+}
+
+/// Summary row for trip statistics
+struct SummaryRow: View {
+    let label: String
+    let value: String
+    
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            
+            Spacer()
+            
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.medium)
+        }
+    }
+}
+
+// MARK: - Preview
+struct ItineraryDisplayView_Previews: PreviewProvider {
+    static var previews: some View {
+        let coordinator = QuestionnaireCoordinator()
+        coordinator.generatedItinerary = MockData.mockItineraryResponse()
+        coordinator.selectedDestination = Destination(
+            id: "dest_001",
+            name: "Barcelona, Spain",
+            country: "Spain",
+            matchScore: 92,
+            estimatedCost: 1650,
+            highlights: ["Architecture", "Food", "Culture"],
+            whyRecommended: "Perfect match for your preferences",
+            imageURL: nil
+        )
+        
+        return ItineraryDisplayView(coordinator: coordinator)
+    }
+}

--- a/frontend/TravelPlanner/TravelPlanner/Views/Questionnaire/ItinerarySummaryStepView.swift
+++ b/frontend/TravelPlanner/TravelPlanner/Views/Questionnaire/ItinerarySummaryStepView.swift
@@ -107,6 +107,29 @@ struct ItinerarySummaryStepView: View {
             }
             
             Spacer()
+            
+            // Loading overlay when generating itinerary
+            if coordinator.isGeneratingItinerary {
+                VStack(spacing: 20) {
+                    ProgressView()
+                        .scaleEffect(1.5)
+                        .progressViewStyle(CircularProgressViewStyle(tint: .blue))
+                    
+                    VStack(spacing: 8) {
+                        Text("Generating your perfect itinerary...")
+                            .font(.headline)
+                            .fontWeight(.medium)
+                        
+                        Text("This may take a few seconds while we optimize your activities and schedule.")
+                            .font(.body)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(.systemBackground).opacity(0.95))
+                .transition(.opacity)
+            }
         }
         .padding()
     }

--- a/frontend/TravelPlanner/TravelPlanner/Views/Questionnaire/QuestionnaireCoordinator.swift
+++ b/frontend/TravelPlanner/TravelPlanner/Views/Questionnaire/QuestionnaireCoordinator.swift
@@ -18,6 +18,10 @@ class QuestionnaireCoordinator: ObservableObject {
     @Published var selectedActivities: [SuggestedActivity] = []
     @Published var isLoadingSuggestedActivities = false
     
+    // Generated itinerary state
+    @Published var generatedItinerary: ItineraryResponse?
+    @Published var isGeneratingItinerary = false
+    
     var canGoForward: Bool {
         validateCurrentStep().isEmpty
     }
@@ -138,6 +142,8 @@ class QuestionnaireCoordinator: ObservableObject {
             }
         case .itinerarySummary:
             break // Summary step, no validation needed
+        case .itineraryDisplay:
+            break // Display step, no validation needed
         }
         
         // Update published errors on main thread
@@ -154,22 +160,6 @@ class QuestionnaireCoordinator: ObservableObject {
         loadDestinations()
     }
     
-    /// Resets all questionnaire data and returns to welcome step
-    func resetQuestionnaire() {
-        currentStep = .welcome
-        userPreferences = UserPreferences()
-        isCompleted = false
-        validationErrors = []
-        // Reset destination selection state
-        destinationResponse = nil
-        selectedDestination = nil
-        isLoadingDestinations = false
-        // Reset itinerary state
-        itineraryPreferences = ItineraryPreferences()
-        activitySuggestionsResponse = nil
-        selectedActivities = []
-        isLoadingSuggestedActivities = false
-    }
     
     /// Loads destination recommendations based on user preferences
     func loadDestinations() {
@@ -231,14 +221,25 @@ class QuestionnaireCoordinator: ObservableObject {
     
     /// Completes the itinerary summary and generates final itinerary
     func completeItinerarySummary() {
-        // TODO: Call final itinerary generation API
-        completeItineraryQuestionnaire()
+        generateItinerary()
+    }
+    
+    /// Generates the final itinerary and navigates to display view
+    func generateItinerary() {
+        isGeneratingItinerary = true
+        
+        // TODO: Replace with actual API call to /itinerary/generate
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.generatedItinerary = MockData.mockItineraryResponse()
+            self.isGeneratingItinerary = false
+            // Only navigate after loading completes
+            self.currentStep = .itineraryDisplay
+        }
     }
     
     /// Completes the entire questionnaire flow
     func completeItineraryQuestionnaire() {
         isCompleted = true
-        // TODO: Navigate to final itinerary view
     }
     
     /// Helper to convert date strings to Date objects for validation
@@ -246,5 +247,22 @@ class QuestionnaireCoordinator: ObservableObject {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.date(from: dateString)
+    }
+    
+    /// Resets questionnaire to start over
+    func resetQuestionnaire() {
+        currentStep = .welcome
+        userPreferences = UserPreferences()
+        itineraryPreferences = ItineraryPreferences()
+        destinationResponse = nil
+        selectedDestination = nil
+        activitySuggestionsResponse = nil
+        selectedActivities = []
+        generatedItinerary = nil
+        isLoadingDestinations = false
+        isLoadingSuggestedActivities = false
+        isGeneratingItinerary = false
+        isCompleted = false
+        validationErrors = []
     }
 }

--- a/frontend/TravelPlanner/TravelPlanner/Views/Questionnaire/QuestionnaireView.swift
+++ b/frontend/TravelPlanner/TravelPlanner/Views/Questionnaire/QuestionnaireView.swift
@@ -41,7 +41,7 @@ struct QuestionnaireView: View {
             .navigationTitle(coordinator.currentStep.title)
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarBackButtonHidden(true)
-            .toolbar {
+            .toolbar(content: {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Cancel") {
                         withAnimation(.easeInOut(duration: 0.3)) {
@@ -49,7 +49,7 @@ struct QuestionnaireView: View {
                         }
                     }
                 }
-            }
+            })
             .safeAreaInset(edge: .top) {
                 // Progress Bar positioned below navigation bar
                 ProgressView(value: coordinator.currentStep.progress)
@@ -109,6 +109,8 @@ struct QuestionnaireView: View {
             TransportationStepView(coordinator: coordinator)
         case .itinerarySummary:
             ItinerarySummaryStepView(coordinator: coordinator)
+        case .itineraryDisplay:
+            ItineraryDisplayView(coordinator: coordinator)
         }
     }
     
@@ -140,29 +142,32 @@ struct QuestionnaireView: View {
             
             Spacer()
             
-            // Next/Finish Button
-            Button(nextButtonText) {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    switch coordinator.currentStep {
-                    case .summary:
-                        coordinator.completeQuestionnaire()
-                    case .destinationSelection:
-                        coordinator.nextStep() // Move to activity types step
-                    case .activityTypes:
-                        coordinator.completeActivityTypes()
-                    case .activitySelection:
-                        coordinator.selectActivities(coordinator.selectedActivities)
-                    case .itinerarySummary:
-                        coordinator.completeItinerarySummary()
-                    default:
-                        coordinator.nextStep()
+            // Next/Finish Button (hide on itinerary display)
+            if coordinator.currentStep != .itineraryDisplay {
+                Button(nextButtonText) {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        switch coordinator.currentStep {
+                        case .summary:
+                            coordinator.completeQuestionnaire()
+                        case .destinationSelection:
+                            coordinator.nextStep() // Move to activity types step
+                        case .activityTypes:
+                            coordinator.completeActivityTypes()
+                        case .activitySelection:
+                            coordinator.selectActivities(coordinator.selectedActivities)
+                        case .itinerarySummary:
+                            coordinator.completeItinerarySummary()
+                        default:
+                            coordinator.nextStep()
+                        }
                     }
                 }
+                .disabled(!coordinator.canGoForward || coordinator.isGeneratingItinerary)
+                .buttonStyle(.borderedProminent)
+                .opacity((coordinator.canGoForward && !coordinator.isGeneratingItinerary) ? 1.0 : 0.6)
             }
-            .disabled(!coordinator.canGoForward)
-            .buttonStyle(.borderedProminent)
-            .opacity(coordinator.canGoForward ? 1.0 : 0.6)
         }
+        .opacity(coordinator.currentStep == .itineraryDisplay ? 0 : 1)
     }
 }
 


### PR DESCRIPTION
## Summary
Completes the travel planning flow by adding the final itinerary display that users see after clicking "Generate Itinerary".

## What's included
- **Complete itinerary view** showing day-by-day schedule with expandable cards
- **Timeline activities** with start/end times, activity types, and notes
- **Trip summary** with estimated costs and optimization score
- **Loading states** that show immediately when generating the itinerary
- **Action buttons** for exporting (placeholder) and starting over

## Key improvements
- Changed all cost references to "estimated" to set proper user expectations
- Added smooth loading overlay during the 2-second API simulation
- Daily cards expand/collapse to show detailed activity timelines
- Comprehensive 7-day Barcelona itinerary with realistic activities and costs

The questionnaire flow is now complete from welcome screen through final itinerary display\!